### PR TITLE
Fix thread safe init and model load

### DIFF
--- a/keyutils.cpp
+++ b/keyutils.cpp
@@ -18,6 +18,7 @@
 
 #include <unordered_set>
 #include <fstream>
+#include <mutex>
 
 #define SHA256_DIGEST_LENGTH 32
 
@@ -130,11 +131,10 @@ std::string private_key_to_address(const std::string& private_key_hex, bool use_
     }
 
     static Secp256K1 secp_k1_instance;
-    static bool secp_k1_initialized = false;
-    if (!secp_k1_initialized) {
+    static std::once_flag secp_k1_init_flag;
+    std::call_once(secp_k1_init_flag, [](){
         secp_k1_instance.Init();
-        secp_k1_initialized = true;
-    }
+    });
 
     Int priv_int;
     priv_int.SetBase16(private_key_hex.c_str());

--- a/ml_engine.cpp
+++ b/ml_engine.cpp
@@ -275,7 +275,12 @@ bool load_models(const std::string& mlp_path_param) {
         } else { std::cerr << "[ML] Falha ao carregar modelo LightGBM: " << LGBM_GetLastError() << std::endl; std::cerr.flush(); }
     } else { std::cout << "[ML] Arquivo LightGBM não encontrado: " << lgb_model_path << std::endl; std::cout.flush(); }
     std::cout << "[DEBUG LM_GLOBAL] Ponto LM8: Saindo de load_models." << std::endl; std::cout.flush();
-    return mlp_g_loaded || ae_g_loaded || xgb_loaded || lgb_loaded;
+
+    bool all_loaded = mlp_g_loaded && ae_g_loaded && xgb_loaded && lgb_loaded;
+    if (!all_loaded) {
+        std::cerr << "[ML] Nem todos os modelos auxiliares foram carregados corretamente." << std::endl;
+    }
+    return all_loaded;
 }
 
 // DEFINIÇÃO DE ml_load_puzzle_patterns MOVIDA PARA ANTES DE ml_init


### PR DESCRIPTION
## Summary
- ensure `Secp256K1` initialization in `private_key_to_address` is thread-safe
- fail ML model loading if any auxiliary model is missing

## Testing
- `pip install numpy pandas torch scikit-learn`
- `pytest -q tests/test_ml_pipeline.py tests/test_rl_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68598975dee48322a2f2b8d0a88d8446